### PR TITLE
Enhance database migration for resetting stale handoff claims

### DIFF
--- a/blueclue/database/SETUP.ps1
+++ b/blueclue/database/SETUP.ps1
@@ -349,7 +349,7 @@ Write-Host ""
 Write-Host "============================================================================" -ForegroundColor Cyan
 Write-Host "Step 4.10: Applying remaining feature migrations..." -ForegroundColor Yellow
 Write-Host "============================================================================" -ForegroundColor Cyan
-Write-Host "Adding themes, pgvector/RAG, chat tech mode, handoff, search indexes, feedback, attachments, and email type fix..." -ForegroundColor White
+Write-Host "Adding themes, pgvector/RAG, chat tech mode, handoff, search indexes, feedback, attachments, email type fix, and stale handoff reset..." -ForegroundColor White
 
 $remainingMigrations = @(
     "migrations\021_add_user_themes.sql",
@@ -360,7 +360,8 @@ $remainingMigrations = @(
     "migrations\033_add_feedback_analytics_system.sql",
     "migrations\034_add_ticket_attachments.sql",
     "migrations\035_add_ring_response_email_type.sql",
-    "migrations\036_fix_chat_sender_and_notification_type.sql"
+    "migrations\036_fix_chat_sender_and_notification_type.sql",
+    "migrations\037_reset_stale_handoff_claims.sql"
 )
 
 $remainingApplied = 0

--- a/blueclue/database/migrations/037_reset_stale_handoff_claims.sql
+++ b/blueclue/database/migrations/037_reset_stale_handoff_claims.sql
@@ -1,0 +1,25 @@
+-- Migration 037: Reset stale/orphaned handoff claims
+-- ====================================================
+-- Date: 2026-03-06
+-- Description:
+--   A conversation re-used for a new handoff request retains the
+--   handoff_claimed_by value from a prior session.  The pending-queue
+--   query filters "AND handoff_claimed_by IS NULL", so those conversations
+--   silently disappear from the tech panel.
+--
+--   This migration clears any stale claim on conversations where a brand-new
+--   handoff request has been made *after* the previous claim was stamped.
+--   It is safe to run multiple times (rows that already have NULLs are no-ops).
+--
+--   Going forward, the application now resets these fields itself when
+--   requestHandoff() is called and when resolveHandoff() closes the chat.
+
+UPDATE chat_conversations
+SET handoff_claimed_by  = NULL,
+    handoff_claimed_at  = NULL,
+    handoff_resolved_at = NULL,
+    ended_at            = NULL
+WHERE handoff_requested_at IS NOT NULL          -- a live request exists
+  AND handoff_claimed_at   IS NOT NULL          -- but it has a stale claim stamp
+  AND handoff_requested_at > handoff_claimed_at -- the new request came AFTER the old claim
+  AND ended_at             IS NULL;             -- and the conversation hasn't been cleanly closed


### PR DESCRIPTION
Include a migration that clears stale claims on conversations with new handoff requests, ensuring they are visible in the tech panel. This update improves the handling of handoff claims in the application.