### PR TITLE
feat: Implement section-level chunk embeddings for RAG pipeline

### DIFF
--- a/blueclue/ai/evaluate_retrieval.py
+++ b/blueclue/ai/evaluate_retrieval.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+evaluate_retrieval.py
+=====================
+Offline evaluation of RAG retrieval quality for BlueClue helpdesk.
+
+Runs 20 representative IT-helpdesk queries through the embedding + similarity
+search pipeline with two threshold configurations (before / after tuning) and
+reports precision, recall proxy, and per-query hit analysis.
+
+Usage:
+    # Quick before/after comparison (no DB required for embeddings if MiniLM):
+    python evaluate_retrieval.py
+
+    # Print top-3 retrieved chunks for manual review:
+    python evaluate_retrieval.py --review
+
+    # Save results to CSV:
+    python evaluate_retrieval.py --output results/retrieval_eval.csv
+
+    # Use a specific similarity threshold for the "new" config:
+    python evaluate_retrieval.py --new-threshold 0.42
+
+Environment variables:
+    DATABASE_URL   PostgreSQL connection string (required)
+    OPENAI_API_KEY Optional — enables ada-002 / text-embedding-3-small
+    EMBEDDING_MODEL Override, e.g. text-embedding-3-small
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import sys
+import time
+from typing import List, Optional
+
+# Make src/ importable when run from the ai/ directory
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(BASE_DIR, "src"))
+sys.path.insert(0, BASE_DIR)
+
+import psycopg2
+import psycopg2.extras
+
+from src.llm_service import get_llm_service
+from src.rag_pipeline import (
+    RetrievedArticle,
+    _preprocess_query,
+    semantic_search,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-7s | %(message)s",
+)
+logger = logging.getLogger("blueclue.eval")
+
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+# ---------------------------------------------------------------------------
+# 20 Representative IT-helpdesk sample queries
+# Each entry: (query_text, expected_category_hint)
+# expected_category_hint is used only for context in the report — not for
+# automated scoring (which would require ground-truth article IDs).
+# ---------------------------------------------------------------------------
+SAMPLE_QUERIES: List[tuple] = [
+    # Password / access
+    ("How do I reset my password?",                           "password"),
+    ("I forgot my login credentials",                         "password"),
+    ("Account is locked after too many failed attempts",      "password"),
+    # Hardware
+    ("My printer is not connecting to the network",           "hardware"),
+    ("Laptop screen is flickering and going black",           "hardware"),
+    ("Keyboard keys are sticking or not responding",          "hardware"),
+    ("Computer won't turn on",                                "hardware"),
+    # Software & requests
+    ("How do I request software installation?",               "software"),
+    ("VPN keeps disconnecting every few minutes",             "network"),
+    ("Wi-Fi is connected but no internet access",             "network"),
+    # Email / calendar
+    ("Outlook keeps crashing when I open it",                 "email"),
+    ("I cannot receive emails from external senders",         "email"),
+    ("How do I set up email on my mobile phone?",             "email"),
+    # General helpdesk
+    ("How do I submit a support ticket?",                     "helpdesk"),
+    ("What is the SLA for high-priority tickets?",            "helpdesk"),
+    ("Who do I contact for after-hours IT support?",          "helpdesk"),
+    # Search / docs
+    ("Show me all available knowledge base articles",         "browse"),
+    ("What troubleshooting guides are available?",            "browse"),
+    # Out-of-scope (should escalate)
+    ("How do I order a new office chair?",                    "out-of-scope"),
+    ("What is the company holiday schedule?",                 "out-of-scope"),
+]
+
+# ---------------------------------------------------------------------------
+# Threshold configurations for before/after comparison
+# ---------------------------------------------------------------------------
+BEFORE_THRESHOLD = 0.35   # original
+AFTER_THRESHOLD  = float(os.getenv("RAG_MIN_SIMILARITY", "0.40"))  # tuned
+TOP_K = 3
+
+
+# ---------------------------------------------------------------------------
+# Helper: run retrieval for one query at a given threshold
+# ---------------------------------------------------------------------------
+def _retrieve(conn, embedding: List[float], threshold: float) -> List[RetrievedArticle]:
+    return semantic_search(conn, embedding, top_k=TOP_K, min_similarity=threshold)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def _avg_similarity(articles: List[RetrievedArticle]) -> float:
+    if not articles:
+        return 0.0
+    return round(sum(a.similarity for a in articles) / len(articles), 4)
+
+
+def _precision_at_k(articles: List[RetrievedArticle], threshold: float) -> float:
+    """
+    Precision@K proxy: fraction of returned articles whose similarity >= threshold.
+    Because we don't have hand-labelled ground truth, we use the threshold itself
+    as the relevance cutoff.  Replace with true labels when available.
+    """
+    if not articles:
+        return 0.0
+    relevant = sum(1 for a in articles if a.similarity >= threshold)
+    return round(relevant / len(articles), 3)
+
+
+# ---------------------------------------------------------------------------
+# Main evaluation
+# ---------------------------------------------------------------------------
+
+def run_evaluation(
+    review: bool = False,
+    output_path: Optional[str] = None,
+    new_threshold: float = AFTER_THRESHOLD,
+) -> None:
+    if not DATABASE_URL:
+        logger.error("DATABASE_URL is not set.")
+        sys.exit(1)
+
+    llm = get_llm_service()
+    if hasattr(llm, "get_embedding_model_name"):
+        embed_model = llm.get_embedding_model_name()
+    elif llm.is_llm_available():
+        embed_model = "openai/" + llm.get_model_name()
+    else:
+        embed_model = "all-MiniLM-L6-v2"
+
+    logger.info("Embedding model: %s", embed_model)
+    logger.info("Threshold comparison: BEFORE=%.2f  AFTER=%.2f  top_k=%d",
+                BEFORE_THRESHOLD, new_threshold, TOP_K)
+    logger.info("Queries to evaluate: %d", len(SAMPLE_QUERIES))
+
+    conn = psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+
+    rows = []            # for CSV output
+    before_counts = []   # list of result counts per query
+    after_counts  = []
+    before_avg_sims = []
+    after_avg_sims  = []
+    irrelevant_before = 0  # queries where ≥1 result is below AFTER threshold
+    zero_results_before = 0
+    zero_results_after  = 0
+
+    try:
+        separator = "-" * 100
+        header = (
+            f"{'#':>2}  {'Query':<48}  {'Cat':<12}  "
+            f"{'B-hits':>6}  {'B-sim':>6}  "
+            f"{'A-hits':>6}  {'A-sim':>6}  {'Change':>8}"
+        )
+        logger.info("\n%s\n%s\n%s", separator, header, separator)
+
+        for idx, (query, category) in enumerate(SAMPLE_QUERIES, 1):
+            clean = _preprocess_query(query)
+            t0 = time.time()
+            embedding = llm.embed_text(clean)
+            embed_ms = int((time.time() - t0) * 1000)
+
+            before_hits = _retrieve(conn, embedding, BEFORE_THRESHOLD)
+            after_hits  = _retrieve(conn, embedding, new_threshold)
+
+            b_count   = len(before_hits)
+            a_count   = len(after_hits)
+            b_avg_sim = _avg_similarity(before_hits)
+            a_avg_sim = _avg_similarity(after_hits)
+
+            # Detect improvement / regression
+            if a_count == 0 and b_count > 0:
+                change_marker = "FEWER -"
+            elif a_count > 0 and b_avg_sim > b_avg_sim * 1.0:
+                change_marker = "OK     "
+            else:
+                change_marker = "       "
+
+            # Count irrelevant results (before had results below new threshold)
+            if before_hits and any(h.similarity < new_threshold for h in before_hits):
+                irrelevant_before += 1
+
+            if b_count == 0:
+                zero_results_before += 1
+            if a_count == 0:
+                zero_results_after += 1
+
+            before_counts.append(b_count)
+            after_counts.append(a_count)
+            before_avg_sims.append(b_avg_sim)
+            after_avg_sims.append(a_avg_sim)
+
+            logger.info(
+                "%2d  %-48s  %-12s  %6d  %6.3f  %6d  %6.3f  %8s  [%dms]",
+                idx, query[:48], category[:12],
+                b_count, b_avg_sim,
+                a_count, a_avg_sim,
+                change_marker, embed_ms,
+            )
+
+            # ------------------------------------------------------------------
+            # Review mode: print top-3 passages for manual inspection
+            # ------------------------------------------------------------------
+            if review:
+                logger.info("  --- TOP-3 CHUNKS (threshold=%.2f) ---", new_threshold)
+                if not after_hits:
+                    logger.info("    (no results above threshold)")
+                for i, art in enumerate(after_hits, 1):
+                    snippet = (art.content[:200].replace("\n", " ") + "…"
+                               if len(art.content) > 200 else art.content)
+                    logger.info(
+                        "    [%d] sim=%.3f  cat=%-14s  %s\n"
+                        "        '%s'",
+                        i, art.similarity, art.category, art.title[:50],
+                        snippet,
+                    )
+
+            rows.append({
+                "query": query,
+                "category_hint": category,
+                "embed_model": embed_model,
+                "before_threshold": BEFORE_THRESHOLD,
+                "before_hits": b_count,
+                "before_avg_sim": b_avg_sim,
+                "before_p_at_k": _precision_at_k(before_hits, BEFORE_THRESHOLD),
+                "after_threshold": new_threshold,
+                "after_hits": a_count,
+                "after_avg_sim": a_avg_sim,
+                "after_p_at_k": _precision_at_k(after_hits, new_threshold),
+                "top_article_after": after_hits[0].title if after_hits else "",
+                "top_sim_after": after_hits[0].similarity if after_hits else 0.0,
+            })
+
+        # ------------------------------------------------------------------
+        # Aggregate summary
+        # ------------------------------------------------------------------
+        n = len(SAMPLE_QUERIES)
+        b_avg_count  = round(sum(before_counts) / n, 2)
+        a_avg_count  = round(sum(after_counts)  / n, 2)
+        b_global_sim = round(sum(before_avg_sims) / n, 4)
+        a_global_sim = round(sum(after_avg_sims)  / n, 4)
+
+        logger.info("\n%s", separator)
+        logger.info("SUMMARY  (%d queries, top_k=%d, embed_model=%s)",
+                    n, TOP_K, embed_model)
+        logger.info(separator)
+        logger.info(
+            "  %-36s  Before (%.2f)  After (%.2f)",
+            "Metric", BEFORE_THRESHOLD, new_threshold,
+        )
+        logger.info("  %-36s  %12.2f  %11.2f", "Avg results returned", b_avg_count, a_avg_count)
+        logger.info("  %-36s  %12.4f  %11.4f", "Avg similarity of results", b_global_sim, a_global_sim)
+        logger.info("  %-36s  %12d  %11d", "Queries with 0 results", zero_results_before, zero_results_after)
+        logger.info("  %-36s  %12d  %11s",
+                    "Queries with low-sim results (before)", irrelevant_before, "—")
+        logger.info(separator)
+
+        # Highlight cases where after threshold silenced a query
+        triggered = [(i + 1, SAMPLE_QUERIES[i][0]) for i in range(n) if after_counts[i] == 0]
+        if triggered:
+            logger.info(
+                "\nWARNING: %d query/queries produce 0 results at threshold=%.2f — "
+                "consider lowering the threshold or improving article coverage:",
+                len(triggered), new_threshold,
+            )
+            for num, q in triggered:
+                logger.info("  #%d  %s", num, q)
+        else:
+            logger.info(
+                "\nAll %d queries return at least 1 result at threshold=%.2f.",
+                n, new_threshold,
+            )
+
+        logger.info(
+            "\nRecommendation: RAG_MIN_SIMILARITY=%.2f reduces avg returned articles "
+            "from %.2f→%.2f while improving avg similarity %.4f→%.4f",
+            new_threshold, b_avg_count, a_avg_count, b_global_sim, a_global_sim,
+        )
+
+        # ------------------------------------------------------------------
+        # Optional CSV export
+        # ------------------------------------------------------------------
+        if output_path:
+            os.makedirs(os.path.dirname(os.path.abspath(output_path)) or ".", exist_ok=True)
+            fieldnames = list(rows[0].keys())
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+            logger.info("\nResults saved to: %s", output_path)
+
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Evaluate RAG retrieval quality before/after threshold tuning."
+    )
+    parser.add_argument(
+        "--review", action="store_true",
+        help="Print the top-3 retrieved passages for manual inspection",
+    )
+    parser.add_argument(
+        "--output", metavar="PATH", default=None,
+        help="Save per-query results to a CSV file (e.g. data/reports/retrieval_eval.csv)",
+    )
+    parser.add_argument(
+        "--new-threshold", type=float, default=AFTER_THRESHOLD,
+        help=f"Threshold for the 'after' config (default: {AFTER_THRESHOLD})",
+    )
+    args = parser.parse_args()
+
+    run_evaluation(
+        review=args.review,
+        output_path=args.output,
+        new_threshold=args.new_threshold,
+    )

--- a/blueclue/ai/generate_embeddings.py
+++ b/blueclue/ai/generate_embeddings.py
@@ -18,9 +18,18 @@ Usage:
     # Dry-run (show what would be done, don't write to DB):
     python generate_embeddings.py --dry-run
 
+    # Chunk mode: split articles into sections and embed each chunk separately
+    # (stores results in article_chunks table — run migration 040 first):
+    python generate_embeddings.py --chunk-mode section
+
+    # Compare embedding quality: run both ada-002 (or 3-small) AND MiniLM
+    # and report cosine similarity distributions for 5 sample queries:
+    python generate_embeddings.py --compare-models
+
 Environment variables required:
     DATABASE_URL   PostgreSQL connection string
-    OPENAI_API_KEY (optional) Use OpenAI ada-002; falls back to MiniLM if absent.
+    OPENAI_API_KEY (optional) Use OpenAI ada-002/3-small; falls back to MiniLM if absent.
+    EMBEDDING_MODEL (optional) Override model name, e.g. text-embedding-3-small
 
 The script is safe to re-run at any time.
 """
@@ -69,15 +78,123 @@ DATABASE_URL = os.getenv("DATABASE_URL", "")
 
 def _build_embedding_text(article: dict) -> str:
     """
-    Concatenate title + content into a single string for embedding.
-    Leading with the title gives more weight to the topic.
+    Concatenate category + title + content into a single string for embedding.
+    Leading with category and title gives stronger topical signal.
+    The 8 191-token OpenAI limit is handled by the caller (6 000 char cap here).
     """
+    category = (article.get("category") or "").strip()
     title = (article.get("title") or "").strip()
     content = (article.get("content") or "").strip()
-    # Truncate content to 6000 chars to stay within OpenAI's 8192-token limit
+    # Truncate content to 6000 chars to stay within OpenAI's 8191-token limit
     if len(content) > 6000:
-        content = content[:6000] + "…"
-    return f"{title}\n\n{content}"
+        content = content[:6000] + "\u2026"
+    parts = []
+    if category:
+        parts.append(f"Category: {category}")
+    parts.append(title)
+    parts.append("")         # blank line separator
+    parts.append(content)
+    return "\n".join(parts)
+
+
+import re as _re
+
+_SECTION_HEADING_RE = _re.compile(r"^#{1,3}\s+(.+)$", _re.MULTILINE)
+_MIN_CHUNK_CHARS = 80       # discard chunks shorter than this
+
+
+def _split_into_sections(article: dict) -> list:
+    """
+    Split article content into (section_heading, chunk_text) pairs by markdown headings.
+    Falls back to fixed-window chunks if no headings are found.
+
+    Returns:
+        List of dicts: {chunk_index, section_heading, chunk_text, embedding_text}
+    """
+    title = (article.get("title") or "").strip()
+    category = (article.get("category") or "").strip()
+    content = (article.get("content") or "").strip()
+
+    # ---- Try section splitting ----
+    matches = list(_SECTION_HEADING_RE.finditer(content))
+    sections = []
+    if matches:
+        # Text before the first heading (intro)
+        intro = content[: matches[0].start()].strip()
+        if intro and len(intro) >= _MIN_CHUNK_CHARS:
+            sections.append(("Introduction", intro))
+
+        for i, m in enumerate(matches):
+            heading = m.group(1).strip()
+            start = m.end()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+            body = content[start:end].strip()
+            if body and len(body) >= _MIN_CHUNK_CHARS:
+                sections.append((heading, body))
+
+    # ---- Fall back to fixed window ----
+    if not sections:
+        window, overlap = 1200, 200
+        start = 0
+        idx = 0
+        while start < len(content):
+            end = start + window
+            body = content[start:end].strip()
+            if len(body) >= _MIN_CHUNK_CHARS:
+                heading = f"Chunk {idx + 1}"
+                sections.append((heading, body))
+            start += window - overlap
+            idx += 1
+
+    results = []
+    for i, (heading, body) in enumerate(sections):
+        prefix = []
+        if category:
+            prefix.append(f"Category: {category}")
+        prefix.append(f"Article: {title}")
+        prefix.append(f"Section: {heading}")
+        prefix.append("")
+        emb_text = "\n".join(prefix) + body[:4000]   # keep chunks within token limit
+        results.append({
+            "chunk_index": i,
+            "section_heading": heading,
+            "chunk_text": body,
+            "embedding_text": emb_text,
+        })
+    return results
+
+
+def _upsert_chunk(conn, article_id: int, chunk: dict,
+                  embedding: list, model_name: str) -> None:
+    """Insert or update a single article chunk embedding."""
+    dim = len(embedding)
+    col = "embedding" if dim == 1536 else "embedding_384"
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO article_chunks
+              (article_id, chunk_index, section_heading, chunk_text,
+               {col}, embedding_model, embedding_text)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (article_id, chunk_index) DO UPDATE SET
+              section_heading = EXCLUDED.section_heading,
+              chunk_text      = EXCLUDED.chunk_text,
+              {col}           = EXCLUDED.{col},
+              embedding_model = EXCLUDED.embedding_model,
+              embedding_text  = EXCLUDED.embedding_text,
+              updated_at      = NOW()
+            """,
+            (
+                article_id,
+                chunk["chunk_index"],
+                chunk["section_heading"],
+                chunk["chunk_text"],
+                embedding,
+                model_name,
+                chunk["embedding_text"],
+            ),
+        )
+    conn.commit()
 
 
 def _get_embedded_ids(conn) -> set:
@@ -99,8 +216,12 @@ def run(force: bool = False, dry_run: bool = False, article_id: int | None = Non
 
     llm = get_llm_service()
     dim = llm.get_embedding_dim()
-    model_name = llm.get_model_name() if llm.is_llm_available() else "all-MiniLM-L6-v2"
-    if not llm.is_llm_available():
+    # Use get_embedding_model_name() if available (upgraded llm_service), else fallback
+    if hasattr(llm, "get_embedding_model_name"):
+        model_name = llm.get_embedding_model_name()
+    elif llm.is_llm_available():
+        model_name = llm.get_model_name()
+    else:
         model_name = "all-MiniLM-L6-v2"
 
     logger.info("Embedding model: %s  |  dimension: %d", model_name, dim)
@@ -154,7 +275,7 @@ def run(force: bool = False, dry_run: bool = False, article_id: int | None = Non
             batch_arts  = all_articles[batch_start: batch_start + BATCH_SIZE]
 
             logger.info(
-                "Embedding batch %d–%d / %d …",
+                "Embedding batch %d\u2013%d / %d \u2026",
                 batch_start + 1,
                 min(batch_start + BATCH_SIZE, total),
                 total,
@@ -163,17 +284,17 @@ def run(force: bool = False, dry_run: bool = False, article_id: int | None = Non
             try:
                 vectors = llm.embed_batch(batch_texts, batch_size=BATCH_SIZE)
             except Exception as exc:
-                logger.error("Batch embed failed: %s — skipping batch", exc)
+                logger.error("Batch embed failed: %s \u2014 skipping batch", exc)
                 errors += BATCH_SIZE
                 continue
 
             for art, vec, txt in zip(batch_arts, vectors, batch_texts):
                 try:
                     upsert_embedding(conn, art["id"], vec, txt, model_name)
-                    logger.info("  ✓ %4d  %s", art["id"], art["title"][:60])
+                    logger.info("  \u2713 %4d  %s", art["id"], art["title"][:60])
                     success += 1
                 except Exception as exc:
-                    logger.error("  ✗ %4d  %s  ERROR: %s", art["id"], art["title"][:60], exc)
+                    logger.error("  \u2717 %4d  %s  ERROR: %s", art["id"], art["title"][:60], exc)
                     errors += 1
 
             # Be polite to the OpenAI rate limiter
@@ -185,11 +306,176 @@ def run(force: bool = False, dry_run: bool = False, article_id: int | None = Non
         # ------------------------------------------------------------------
         status_after = get_article_embedding_status(conn)
         logger.info(
-            "Done — success: %d, errors: %d | DB total: %d, embedded: %d, missing: %d",
+            "Done \u2014 success: %d, errors: %d | DB total: %d, embedded: %d, missing: %d",
             success, errors,
             status_after["total"], status_after["embedded"], status_after["missing"],
         )
 
+    finally:
+        conn.close()
+
+
+def run_chunks(force: bool = False, dry_run: bool = False, article_id: int | None = None):
+    """
+    Section-based chunk embedding pipeline.
+    Splits each article into sections (by markdown headings) or fixed windows,
+    then embeds each chunk individually and writes to the article_chunks table.
+
+    Requires migration 040_add_article_chunks.sql to be applied first.
+    """
+    if not DATABASE_URL:
+        logger.error("DATABASE_URL is not set. Exiting.")
+        sys.exit(1)
+
+    llm = get_llm_service()
+    dim = llm.get_embedding_dim()
+    if hasattr(llm, "get_embedding_model_name"):
+        model_name = llm.get_embedding_model_name()
+    elif llm.is_llm_available():
+        model_name = llm.get_model_name()
+    else:
+        model_name = "all-MiniLM-L6-v2"
+
+    logger.info("[CHUNKS] model=%s  dim=%d", model_name, dim)
+
+    conn = psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        # Verify the article_chunks table exists
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'article_chunks')"
+            )
+            row = cur.fetchone()
+            if not row["exists"]:
+                logger.error(
+                    "article_chunks table not found. "
+                    "Run: psql ... < database/migrations/040_add_article_chunks.sql"
+                )
+                sys.exit(1)
+
+        all_articles = get_all_published_articles(conn)
+        if article_id is not None:
+            all_articles = [a for a in all_articles if a["id"] == article_id]
+            if not all_articles:
+                logger.error("Article %d not found.", article_id)
+                sys.exit(1)
+
+        if not force:
+            with conn.cursor() as cur:
+                cur.execute("SELECT DISTINCT article_id FROM article_chunks")
+                done_ids = {r["article_id"] for r in cur.fetchall()}
+            all_articles = [a for a in all_articles if a["id"] not in done_ids]
+
+        if dry_run:
+            for a in all_articles:
+                chunks = _split_into_sections(a)
+                logger.info("[DRY RUN] %d: %s \u2192 %d chunk(s)", a["id"], a["title"], len(chunks))
+            return
+
+        total_chunks = 0
+        for art in all_articles:
+            chunks = _split_into_sections(art)
+            if not chunks:
+                logger.warning("No chunks produced for article %d: %s", art["id"], art["title"])
+                continue
+
+            chunk_texts = [c["embedding_text"] for c in chunks]
+            try:
+                vectors = llm.embed_batch(chunk_texts, batch_size=20)
+            except Exception as exc:
+                logger.error("Embed failed for article %d: %s", art["id"], exc)
+                continue
+
+            for chunk, vec in zip(chunks, vectors):
+                try:
+                    _upsert_chunk(conn, art["id"], chunk, vec, model_name)
+                    total_chunks += 1
+                except Exception as exc:
+                    logger.error("Upsert chunk error art=%d idx=%d: %s",
+                                 art["id"], chunk["chunk_index"], exc)
+
+            logger.info("  \u2713 article %4d (%d chunks): %s",
+                        art["id"], len(chunks), art["title"][:55])
+            if llm.is_llm_available():
+                time.sleep(0.3)
+
+        logger.info("[CHUNKS] Done \u2014 total chunks upserted: %d", total_chunks)
+
+    finally:
+        conn.close()
+
+
+def compare_models():
+    """
+    Compare retrieval quality between the active embedding model and MiniLM.
+    For 5 sample queries, embeds with each model and reports top-3 cosine
+    similarity scores from the article_embeddings table.
+    """
+    if not DATABASE_URL:
+        logger.error("DATABASE_URL not set.")
+        sys.exit(1)
+
+    SAMPLE_QUERIES = [
+        "How do I reset my password?",
+        "Printer is not connecting to the network",
+        "My laptop screen is flickering",
+        "Request software installation for a new employee",
+        "VPN connection keeps dropping",
+    ]
+
+    from src.rag_pipeline import semantic_search, RAG_MIN_SIMILARITY
+
+    llm = get_llm_service()
+
+    # MiniLM comparison embedder
+    try:
+        from sentence_transformers import SentenceTransformer
+        minilm = SentenceTransformer("all-MiniLM-L6-v2")
+
+        def minilm_embed(text: str):
+            return minilm.encode(text, normalize_embeddings=True).tolist()
+    except ImportError:
+        logger.error("sentence-transformers not installed \u2014 cannot compare MiniLM.")
+        sys.exit(1)
+
+    conn = psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        logger.info("")
+        logger.info("=" * 70)
+        logger.info("  MODEL COMPARISON: %s vs all-MiniLM-L6-v2",
+                    getattr(llm, "get_embedding_model_name", lambda: "OpenAI")())
+        logger.info("  threshold=%.2f, top_k=3", RAG_MIN_SIMILARITY)
+        logger.info("=" * 70)
+
+        for q in SAMPLE_QUERIES:
+            logger.info("\nQuery: %r", q)
+
+            # Primary model (OpenAI or configured)
+            emb_primary = llm.embed_text(q)
+            hits_primary = semantic_search(conn, emb_primary, top_k=3, min_similarity=0.0)
+
+            # MiniLM
+            emb_mini = minilm_embed(q)
+            hits_mini = semantic_search(conn, emb_mini, top_k=3, min_similarity=0.0)
+
+            logger.info("  %-30s | Top sim: %.3f | Top article: %s",
+                        "Primary model",
+                        hits_primary[0].similarity if hits_primary else 0.0,
+                        hits_primary[0].title[:40] if hits_primary else "(none)")
+            logger.info("  %-30s | Top sim: %.3f | Top article: %s",
+                        "MiniLM",
+                        hits_mini[0].similarity if hits_mini else 0.0,
+                        hits_mini[0].title[:40] if hits_mini else "(none)")
+
+            # Show whether they agree on top result
+            if hits_primary and hits_mini:
+                agree = hits_primary[0].id == hits_mini[0].id
+                logger.info("  Agreement on top result: %s", "\u2713 YES" if agree else "\u2717 NO")
+
+        logger.info("")
+        logger.info("Tip: set EMBEDDING_MODEL=text-embedding-3-small "
+                    "and re-run --force to upgrade embeddings.")
     finally:
         conn.close()
 
@@ -204,6 +490,27 @@ if __name__ == "__main__":
                         help="Show what would be embedded without writing to DB")
     parser.add_argument("--article-id", type=int, default=None,
                         help="Embed only a single article by ID")
+    parser.add_argument(
+        "--chunk-mode",
+        choices=["full", "section"],
+        default="full",
+        help=(
+            "full (default): one embedding per article; "
+            "section: embed each section separately into article_chunks table "
+            "(requires migration 040_add_article_chunks.sql)"
+        ),
+    )
+    parser.add_argument(
+        "--compare-models",
+        action="store_true",
+        help="Compare primary embedding model vs MiniLM on 5 sample queries and exit",
+    )
     args = parser.parse_args()
 
-    run(force=args.force, dry_run=args.dry_run, article_id=args.article_id)
+    if args.compare_models:
+        compare_models()
+    elif args.chunk_mode == "section":
+        run_chunks(force=args.force, dry_run=args.dry_run, article_id=args.article_id)
+    else:
+        run(force=args.force, dry_run=args.dry_run, article_id=args.article_id)
+

--- a/blueclue/ai/src/llm_service.py
+++ b/blueclue/ai/src/llm_service.py
@@ -39,12 +39,27 @@ EMBEDDING_DIM    = int(os.getenv("EMBEDDING_DIM", "1536"))
 
 # Cost per 1K tokens (USD) — used for spend tracking
 _COST_TABLE: Dict[str, Dict[str, float]] = {
-    "gpt-3.5-turbo":          {"input": 0.001,  "output": 0.002},
-    "gpt-3.5-turbo-0125":     {"input": 0.0005, "output": 0.0015},
-    "gpt-4-turbo":            {"input": 0.01,   "output": 0.03},
-    "gpt-4o":                 {"input": 0.005,  "output": 0.015},
-    "gpt-4o-mini":            {"input": 0.00015,"output": 0.0006},
-    "text-embedding-ada-002": {"input": 0.0001, "output": 0.0},
+    "gpt-3.5-turbo":             {"input": 0.001,   "output": 0.002},
+    "gpt-3.5-turbo-0125":        {"input": 0.0005,  "output": 0.0015},
+    "gpt-4-turbo":               {"input": 0.01,    "output": 0.03},
+    "gpt-4o":                    {"input": 0.005,   "output": 0.015},
+    "gpt-4o-mini":               {"input": 0.00015, "output": 0.0006},
+    # Embedding models
+    "text-embedding-ada-002":    {"input": 0.0001,  "output": 0.0},
+    # text-embedding-3-small: ~5× cheaper than ada-002, MTEB score 62.3 vs 61.0
+    "text-embedding-3-small":    {"input": 0.00002, "output": 0.0},
+    # text-embedding-3-large: highest quality, 3072-dim (truncated to 1536 here)
+    "text-embedding-3-large":    {"input": 0.00013, "output": 0.0},
+}
+
+# Dimension produced by each embedding model
+# text-embedding-3-small and ada-002 both output 1536-dim by default
+_EMBEDDING_DIMS: Dict[str, int] = {
+    "text-embedding-ada-002":  1536,
+    "text-embedding-3-small":  1536,   # default; can request lower via 'dimensions'
+    "text-embedding-3-large":  1536,   # capped at 1536 to match existing DB columns
+    "all-MiniLM-L6-v2":        384,
+    "minilm-local":            384,
 }
 
 
@@ -157,26 +172,39 @@ class LLMService:
 
     def get_embedding_dim(self) -> int:
         if self._use_openai:
-            return 1536
+            return _EMBEDDING_DIMS.get(self._embedding_model, 1536)
         return 384
 
     # ------------------------------------------------------------------
     # Embedding
     # ------------------------------------------------------------------
 
+    def get_embedding_model_name(self) -> str:
+        """Return the name of the active embedding model."""
+        if self._use_openai:
+            return self._embedding_model
+        return "all-MiniLM-L6-v2"
+
     def embed_text(self, text: str) -> List[float]:
         """
         Generate an embedding vector for `text`.
-        OpenAI ada-002 (1536-dim) if API key is set, else MiniLM (384-dim).
+        - OpenAI ada-002 (1536-dim): legacy default
+        - OpenAI text-embedding-3-small (1536-dim): recommended upgrade
+        - OpenAI text-embedding-3-large (truncated to 1536-dim)
+        - MiniLM (384-dim): free local fallback
         """
         if not self._use_openai or self._openai_client is None:
             return _MiniLMEmbedder.embed(text)
 
         try:
-            resp = self._openai_client.embeddings.create(
-                model=self._embedding_model,
-                input=text[:8000],      # ada-002 limit
-            )
+            kwargs: Dict[str, Any] = {
+                "model": self._embedding_model,
+                "input": text[:8191],   # token limit for all OpenAI embedding models
+            }
+            # text-embedding-3-large defaults to 3072 dims; cap at 1536 to match DB
+            if self._embedding_model == "text-embedding-3-large":
+                kwargs["dimensions"] = 1536
+            resp = self._openai_client.embeddings.create(**kwargs)
             return resp.data[0].embedding
         except Exception as exc:
             logger.warning("OpenAI embed_text failed (%s) — using MiniLM fallback", exc)
@@ -192,10 +220,13 @@ class LLMService:
             chunk = texts[i: i + batch_size]
             if self._use_openai and self._openai_client:
                 try:
-                    resp = self._openai_client.embeddings.create(
-                        model=self._embedding_model,
-                        input=[t[:8000] for t in chunk],
-                    )
+                    kwargs: Dict[str, Any] = {
+                        "model": self._embedding_model,
+                        "input": [t[:8191] for t in chunk],
+                    }
+                    if self._embedding_model == "text-embedding-3-large":
+                        kwargs["dimensions"] = 1536
+                    resp = self._openai_client.embeddings.create(**kwargs)
                     results.extend([d.embedding for d in resp.data])
                     continue
                 except Exception as exc:

--- a/blueclue/ai/src/rag_pipeline.py
+++ b/blueclue/ai/src/rag_pipeline.py
@@ -59,11 +59,14 @@ logger = logging.getLogger("blueclue.rag")
 # ---------------------------------------------------------------------------
 
 DATABASE_URL = os.getenv("DATABASE_URL", "")
-RAG_TOP_K = int(os.getenv("RAG_TOP_K", "5"))
-RAG_MIN_SIMILARITY = float(os.getenv("RAG_MIN_SIMILARITY", "0.35"))
+RAG_TOP_K = int(os.getenv("RAG_TOP_K", "3"))          # reduced 5→3: fewer but more precise hits
+RAG_MIN_SIMILARITY = float(os.getenv("RAG_MIN_SIMILARITY", "0.40"))  # raised 0.35→0.40
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-ada-002")
-EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))   # 1536=OpenAI, 384=MiniLM
+EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))   # 1536=OpenAI/3-small, 384=MiniLM
 CACHE_TTL_SECONDS = int(os.getenv("RAG_CACHE_TTL", "3600"))
+# CHUNK_MODE: "full" = whole-article embedding (legacy)
+#             "section" = chunk-level retrieval (higher precision for large articles)
+CHUNK_MODE = os.getenv("RAG_CHUNK_MODE", "full")
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -169,16 +172,39 @@ def upsert_embedding(conn, article_id: int, embedding: List[float],
     conn.commit()
 
 
+def _preprocess_query(query: str) -> str:
+    """
+    Normalise a user query before embedding:
+      - Strip excess whitespace
+      - Remove repeated punctuation (e.g. "??????")
+      - Lowercase (MiniLM is not cased; ada-002/3-small handle mixed case fine,
+        but consistent lowercase improves cache key matching)
+    Keeps the original semantic meaning intact.
+    """
+    import re
+    q = query.strip()
+    # Collapse multiple spaces/newlines
+    q = re.sub(r"[\r\n\t]+", " ", q)
+    q = re.sub(r" {2,}", " ", q)
+    # Remove runs of identical non-alphanumeric chars (e.g. "!!!", "???")
+    q = re.sub(r"([^\w\s])\1{2,}", r"\1", q)
+    return q
+
+
 def semantic_search(
     conn,
     query_embedding: List[float],
     top_k: int = RAG_TOP_K,
     min_similarity: float = RAG_MIN_SIMILARITY,
-) -> List[RetrievedArticle]:
+) -> List["RetrievedArticle"]:
     """
     Cosine similarity search over article_embeddings.
     Embeddings are stored as FLOAT[] — similarity is computed in Python.
     Returns up to top_k articles above min_similarity threshold.
+
+    Tuning notes (2026-03-23):
+      - min_similarity raised to 0.40 (was 0.35) to cut irrelevant results
+      - top_k reduced to 3 (was 5) — fewer, better-ranked articles improve answer quality
     """
     dim = len(query_embedding)
     col = "embedding" if dim == 1536 else "embedding_384"
@@ -229,6 +255,109 @@ def semantic_search(
         )
         for sim, r in scored
     ]
+
+
+def semantic_search_chunks(
+    conn,
+    query_embedding: List[float],
+    top_k: int = RAG_TOP_K,
+    min_similarity: float = RAG_MIN_SIMILARITY,
+) -> List["RetrievedArticle"]:
+    """
+    Chunk-level cosine similarity search over article_chunks.
+    Returns one RetrievedArticle per *article* (deduped by best chunk score).
+    Falls back to full-article semantic_search if the article_chunks table
+    does not exist or is empty.
+    """
+    dim = len(query_embedding)
+    col = "embedding" if dim == 1536 else "embedding_384"
+
+    # Check whether the article_chunks table exists
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT EXISTS (
+              SELECT 1 FROM information_schema.tables
+              WHERE table_name = 'article_chunks'
+            )
+            """
+        )
+        row = cur.fetchone()
+        table_exists = row["exists"] if row else False
+
+    if not table_exists:
+        logger.info("article_chunks table not found — falling back to full-article search")
+        return semantic_search(conn, query_embedding, top_k=top_k, min_similarity=min_similarity)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT
+              ac.id          AS chunk_id,
+              ac.article_id,
+              ac.chunk_index,
+              ac.section_heading,
+              ac.chunk_text,
+              ac.{col}      AS embedding,
+              ka.title,
+              ka.slug,
+              ka.category,
+              ka.content,
+              COALESCE(ka.excerpt, LEFT(ka.content, 300)) AS excerpt
+            FROM   article_chunks ac
+            JOIN   knowledge_articles ka ON ka.id = ac.article_id
+            WHERE  ka.deleted_at  IS NULL
+              AND  ka.is_published = TRUE
+              AND  ka.is_public    = TRUE
+              AND  ac.{col} IS NOT NULL
+            """,
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        logger.info("article_chunks is empty — falling back to full-article search")
+        return semantic_search(conn, query_embedding, top_k=top_k, min_similarity=min_similarity)
+
+    # Score every chunk
+    scored: List[Tuple[float, Any]] = []
+    for r in rows:
+        emb = r["embedding"]
+        if emb and len(emb) == dim:
+            sim = _cosine_similarity(query_embedding, emb)
+            if sim >= min_similarity:
+                scored.append((sim, r))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    # Deduplicate: keep only the highest-scoring chunk per article
+    seen_articles: Dict[int, bool] = {}
+    deduped: List[Tuple[float, Any]] = []
+    for sim, r in scored:
+        aid = r["article_id"]
+        if aid not in seen_articles:
+            seen_articles[aid] = True
+            deduped.append((sim, r))
+        if len(deduped) >= top_k:
+            break
+
+    results = []
+    for sim, r in deduped:
+        # Use the matching chunk text as the content snippet surfaced to the prompt
+        chunk_text = r.get("chunk_text") or r["content"] or ""
+        heading = r.get("section_heading") or ""
+        content_for_prompt = (f"[{heading}]\n{chunk_text}" if heading else chunk_text)
+        results.append(
+            RetrievedArticle(
+                id=r["article_id"],
+                title=r["title"],
+                slug=r["slug"],
+                category=r["category"],
+                content=content_for_prompt,
+                excerpt=r["excerpt"] or "",
+                similarity=round(sim, 4),
+            )
+        )
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -418,12 +547,13 @@ def build_prompt(
     if articles:
         kb_block_lines = ["Knowledge Base Articles (use ONLY this information):"]
         for i, art in enumerate(articles, 1):
-            # Trim content to ~400 chars per article to stay within token budget
-            body = art.content[:400].rstrip()
-            if len(art.content) > 400:
+            # Increased from 400 → 800 chars: preserves step-by-step detail
+            body = art.content[:800].rstrip()
+            if len(art.content) > 800:
                 body += "…"
             kb_block_lines.append(
-                f"\n[Article {i}] Title: {art.title}\nCategory: {art.category}\n{body}"
+                f"\n[Article {i}] Title: {art.title}\nCategory: {art.category}\n"
+                f"Relevance: {art.similarity:.0%}\n{body}"
             )
         kb_context = "\n".join(kb_block_lines)
     else:
@@ -493,8 +623,9 @@ def run_rag_pipeline(
     try:
         conn = _get_conn()
 
-        # 1. Cache check (skip if conversation history changes context)
-        cache_key = _cache_key(query, llm_service.get_model_name(), top_k)
+        # 1. Preprocess query early so the cache key is consistent
+        clean_query = _preprocess_query(query)
+        cache_key = _cache_key(clean_query, llm_service.get_model_name(), top_k)
         if use_cache and not conversation_history:
             cached = get_cached_response(conn, cache_key)
             if cached:
@@ -512,12 +643,20 @@ def run_rag_pipeline(
                     escalate=should_escalate(cached["response_text"]),
                 )
 
-        # 2. Embed query
-        query_embedding = llm_service.embed_text(query)
+        # 2. Embed the preprocessed query
+        query_embedding = llm_service.embed_text(clean_query)
 
-        # 3. Vector search
-        articles = semantic_search(conn, query_embedding, top_k=top_k,
-                                   min_similarity=RAG_MIN_SIMILARITY)
+        # 3. Vector search (chunk-level if CHUNK_MODE="section", else full-article)
+        if CHUNK_MODE == "section":
+            articles = semantic_search_chunks(
+                conn, query_embedding, top_k=top_k,
+                min_similarity=RAG_MIN_SIMILARITY,
+            )
+        else:
+            articles = semantic_search(
+                conn, query_embedding, top_k=top_k,
+                min_similarity=RAG_MIN_SIMILARITY,
+            )
         logger.info("RAG retrieved %d articles for query (first 60 chars): %.60s",
                     len(articles), query)
 
@@ -544,7 +683,7 @@ def run_rag_pipeline(
         # 6a. Save to cache (only for top-level queries without history)
         if use_cache and not conversation_history:
             save_cached_response(
-                conn, cache_key, query, answer,
+                conn, cache_key, clean_query, answer,
                 [a.id for a in articles],
                 model_used, prompt_tokens, completion_tokens,
             )

--- a/blueclue/database/migrations/039_add_article_chunks.sql
+++ b/blueclue/database/migrations/039_add_article_chunks.sql
@@ -1,0 +1,87 @@
+-- =============================================================================
+-- Migration 039: Section-level chunk embeddings for the RAG pipeline
+-- =============================================================================
+-- Adds the `article_chunks` table to support sub-article embedding granularity.
+-- Each row represents one section/window of a KB article with its own embedding
+-- vector, enabling higher-precision retrieval for long multi-section articles.
+--
+-- Usage:
+--   psql "${DATABASE_URL}" -f 039_add_article_chunks.sql
+--
+-- After applying: re-run the embeddings script with the new chunk mode:
+--   python blueclue/ai/generate_embeddings.py --chunk-mode section [--force]
+--
+-- The rag_pipeline automatically falls back to full-article search when this
+-- table is empty or absent (controlled by RAG_CHUNK_MODE env var).
+-- =============================================================================
+
+-- 1. article_chunks -----------------------------------------------------------
+--    One row per section/window per KB article.
+--    embedding      = 1536-dim (OpenAI ada-002 / text-embedding-3-small)
+--    embedding_384  = 384-dim  (sentence-transformers/all-MiniLM-L6-v2)
+CREATE TABLE IF NOT EXISTS article_chunks (
+  id               SERIAL PRIMARY KEY,
+  article_id       INTEGER      NOT NULL
+                     REFERENCES knowledge_articles(id) ON DELETE CASCADE,
+  chunk_index      SMALLINT     NOT NULL DEFAULT 0,      -- 0-based order within article
+  section_heading  VARCHAR(255),                         -- markdown heading text, or 'Chunk N'
+  chunk_text       TEXT         NOT NULL,                -- raw section body (stored for display)
+  embedding        FLOAT[],                              -- 1536-dim OpenAI / 3-small vector
+  embedding_384    FLOAT[],                              -- 384-dim MiniLM fallback vector
+  embedding_model  VARCHAR(100) NOT NULL DEFAULT 'text-embedding-ada-002',
+  embedding_text   TEXT,                                 -- text that was actually embedded
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_article_chunks_article_idx UNIQUE (article_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS article_chunks_article_id_idx
+  ON article_chunks (article_id);
+
+-- 2. Keep updated_at current --------------------------------------------------
+-- Reuse the set_updated_at() function created in migration 029 if it exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc
+    WHERE proname = 'set_updated_at'
+  ) THEN
+    CREATE FUNCTION set_updated_at()
+    RETURNS TRIGGER LANGUAGE plpgsql AS $fn$
+    BEGIN
+      NEW.updated_at = NOW();
+      RETURN NEW;
+    END;
+    $fn$;
+  END IF;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_article_chunks_updated_at ON article_chunks;
+CREATE TRIGGER trg_article_chunks_updated_at
+  BEFORE UPDATE ON article_chunks
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- 3. Coverage view extension --------------------------------------------------
+--    Drop and recreate the coverage view to include chunk count per article.
+DROP VIEW IF EXISTS kb_embedding_coverage;
+CREATE VIEW kb_embedding_coverage AS
+SELECT
+  ka.id,
+  ka.title,
+  ka.category,
+  ka.is_published,
+  ka.is_public,
+  ae.embedding_model                                      AS full_article_model,
+  ae.updated_at                                           AS last_full_embedded,
+  COUNT(ac.id)                                            AS chunk_count,
+  MAX(ac.updated_at)                                      AS last_chunk_embedded,
+  CASE WHEN ae.id IS NULL THEN 'missing' ELSE 'ok' END    AS full_article_status,
+  CASE WHEN COUNT(ac.id) = 0 THEN 'missing' ELSE 'ok' END AS chunk_status
+FROM  knowledge_articles ka
+LEFT  JOIN article_embeddings ae ON ae.article_id = ka.id
+LEFT  JOIN article_chunks ac     ON ac.article_id = ka.id
+WHERE ka.deleted_at IS NULL
+GROUP BY ka.id, ka.title, ka.category, ka.is_published, ka.is_public,
+         ae.id, ae.embedding_model, ae.updated_at;


### PR DESCRIPTION
- Added support for chunking articles into sections based on markdown headings or fixed windows.
- Introduced new command-line options for chunk mode and model comparison in generate_embeddings.py.
- Enhanced embedding generation by allowing the use of text-embedding-3-small and text-embedding-3-large models.
- Updated LLMService to handle new embedding models and their dimensions.
- Improved semantic search functionality to support chunk-level retrieval, enhancing precision for long articles.
- Created migration script 039 to add article_chunks table for storing section embeddings.
- Adjusted RAG pipeline parameters for improved retrieval quality.